### PR TITLE
Handle implicit rendering

### DIFF
--- a/lib/rails-route-checker/app_interface.rb
+++ b/lib/rails-route-checker/app_interface.rb
@@ -10,7 +10,12 @@ module RailsRouteChecker
         action = r.requirements[:action]
 
         next if options[:ignored_controllers].include?(controller)
-        next if controller_information.key?(controller) && controller_information[controller][:actions].include?(action)
+
+        if controller_information.key?(controller)
+          info = controller_information[controller]
+          next if info[:actions].include?(action)
+          next if info[:lookup_context] && info[:lookup_context].template_exists?("#{controller}/#{action}")
+        end
 
         {
           controller: controller,

--- a/lib/rails-route-checker/loaded_app.rb
+++ b/lib/rails-route-checker/loaded_app.rb
@@ -41,13 +41,17 @@ module RailsRouteChecker
         next if controller.controller_path.start_with?('rails/')
 
         instance_methods = (controller.instance_methods.map(&:to_s) + controller.private_instance_methods.map(&:to_s))
+        lookup_context = ActionView::LookupContext.new(
+          controller._view_paths, {}, controller._prefixes
+        ) if controller.instance_methods.include?(:default_render)
 
         [
           controller.controller_path,
           {
             helpers: controller.helpers.methods.map(&:to_s),
             actions: controller.action_methods.to_a,
-            instance_methods: instance_methods.compact.uniq
+            instance_methods: instance_methods.compact.uniq,
+            lookup_context: lookup_context
           }
         ]
       end.compact.to_h


### PR DESCRIPTION
First, of all – great work, @daveallie! Thank you!

I ran it against my app and found a little issue.

When [`ActionController::ImplicitRender`](http://api.rubyonrails.org/v5.0/classes/ActionController/ImplicitRender.html) is included (e.g. for `ActionController::Base`), it allows to avoid explicitly defined actions and renders the corresponding templates.

Thus we can check for templates in that case without producing false negatives.