### PR TITLE
wrong return code if only a single violation found

### DIFF
--- a/lib/rails-route-checker/runner.rb
+++ b/lib/rails-route-checker/runner.rb
@@ -14,7 +14,7 @@ module RailsRouteChecker
     end
 
     def issues?
-      issues.values.flatten(1).count > 1
+      issues.values.flatten(1).count > 0
     end
 
     def output


### PR DESCRIPTION
if only a single violation was found, eg:

```
========== Running: bundle exec rails-route-checker
The following 1 url and path methods don't correspond to any route.
- app/views/time_off_mailer/_entry.html.haml:40 - call to entry_calendar_url
========== Finished in 29.68s: bundle exec rails-route-checker
```

`issues?` would return `false`, when it should have returned `true`. 2 or more violations give the expected outcome:

```
========== Running: bundle exec rails-route-checker
The following 2 url and path methods don't correspond to any route.
- app/views/time_off_mailer/_entry.html.haml:43 - call to entry_calendar_url
- app/views/time_off_mailer/_entry.html.haml:45 - call to entry_calendar_url
========== Errored after 19.24s: bundle exec rails-route-checker
```