### PR TITLE
Support controller_paths that are nil

### DIFF
--- a/lib/rails-route-checker/loaded_app.rb
+++ b/lib/rails-route-checker/loaded_app.rb
@@ -51,7 +51,7 @@ module RailsRouteChecker
 
     def controller_information
       @controller_information ||= ActionController::Base.descendants.map do |controller|
-        next if controller.controller_path.start_with?('rails/')
+        next if controller.controller_path.nil? || controller.controller_path.start_with?('rails/')
 
         [
           controller.controller_path,


### PR DESCRIPTION
Rails 6.1 includes one: https://github.com/rails/rails/blob/v6.1.0/actiontext/lib/action_text/engine.rb#L49