### PR TITLE
Ignore Rails default controllers

### DIFF
--- a/lib/rails-route-checker/loaded_app.rb
+++ b/lib/rails-route-checker/loaded_app.rb
@@ -23,7 +23,6 @@ module RailsRouteChecker
       suppress_output do
         @app = Rails.application
         @app.eager_load!
-        attempt_to_load_default_controllers
         @app.reload_routes!
         Rails::Engine.subclasses.each(&:eager_load!)
       end
@@ -95,23 +94,6 @@ module RailsRouteChecker
         $stderr.reopen(original_stderr)
       end
       retval
-    end
-
-    def attempt_to_load_default_controllers
-      # rubocop:disable Lint/SuppressedException
-      begin
-        ::Rails::InfoController
-      rescue NameError # ignored
-      end
-      begin
-        ::Rails::WelcomeController
-      rescue NameError # ignored
-      end
-      begin
-        ::Rails::MailersController
-      rescue NameError # ignored
-      end
-      # rubocop:enable Lint/SuppressedException
     end
 
     def reject_route?(route)

--- a/lib/rails-route-checker/loaded_app.rb
+++ b/lib/rails-route-checker/loaded_app.rb
@@ -23,7 +23,6 @@ module RailsRouteChecker
       suppress_output do
         @app = Rails.application
         @app.eager_load!
-        @app.reload_routes!
         Rails::Engine.subclasses.each(&:eager_load!)
       end
     end


### PR DESCRIPTION
As far as I can tell there's no reason to load them. Users shouldn't interact with these directly and it's unlikely you will route to them. And they always get ignored in `reject_route?`.

@daveallie do you remember why you loaded them?